### PR TITLE
codeberg: handle empty user names

### DIFF
--- a/assign-pull-requests-codeberg.py
+++ b/assign-pull-requests-codeberg.py
@@ -256,8 +256,8 @@ def assign_one(
                             team_reviewers.add(team)
                     else:
                         ms = map_dev(memail, dev_mapping)
-                        u = dev_mapping.get(memail.lower())
-                        if u not in (None, pr_submitter):
+                        u = dev_mapping.get(memail.lower(), "")
+                        if u not in ("", pr_submitter):
                             reviewers.add(u)
 
                     for subm in m:


### PR DESCRIPTION
The dev_mapping dict may contain entries that map to "". This comes from devs.json that contains entries for all developers and have empty strings for developers that do not have (registered) Codeberg accounts.