### PR TITLE
codebergapi: add timeouts to all requests

### DIFF
--- a/codebergapi.py
+++ b/codebergapi.py
@@ -1,5 +1,15 @@
 import requests
+from requests.adapters import HTTPAdapter
 from typing import Generator
+
+
+class TimeoutHTTPAdapter(HTTPAdapter):
+
+    def send(self, request, **kwargs):
+        timeout = kwargs.get("timeout")
+        if timeout is None:
+            kwargs["timeout"] = 5
+        return super().send(request, **kwargs)
 
 
 class CodebergAPI:
@@ -19,6 +29,7 @@ class CodebergAPI:
         self.session.hooks = {
             "response": lambda r, *args, **kwargs: r.raise_for_status()
         }
+        self.session.mount("https://", TimeoutHTTPAdapter())
         return self
 
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
@@ -36,14 +47,14 @@ class CodebergAPI:
     def teams_baseurl(self) -> str:
         return "https://codeberg.org/api/v1/teams"
 
-    def _get_paginated(self, url) -> Generator[None, dict, None]:
-        r = self.session.get(url, params={"limit": 100})
+    def _get_paginated(self, url, timeout=None) -> Generator[None, dict, None]:
+        r = self.session.get(url, params={"limit": 100}, timeout=timeout)
         yield from r.json()
         if "next" not in r.links:
             return
         next_url = r.links["next"]["url"]
         while True:
-            r = self.session.get(next_url)
+            r = self.session.get(next_url, timeout=timeout)
             yield from r.json()
             if "next" not in r.links:
                 break
@@ -53,7 +64,7 @@ class CodebergAPI:
         """
         state must be one of: open, closed, all
         """
-        return self._get_paginated(f"{self.repos_baseurl}/pulls?state={state}")
+        return self._get_paginated(f"{self.repos_baseurl}/pulls?state={state}", timeout=61)
 
     def set_pr_title(self, pr_id: int, title: str) -> None:
         self.session.patch(f"{self.repos_baseurl}/pulls/{pr_id}", json={"title": title})


### PR DESCRIPTION
Set a default timeout of 5 seconds for all requests except fetching PRs on /pulls. Codeberg has set a timeout of 60 seconds so we (almost) match that. The requests docs state that timeouts should be set to a value slightly higher than a multiple of three.