### PR TITLE
codeberg: fix "See Also" urls posted to bugzilla

### DIFF
--- a/assign-pull-requests-codeberg.py
+++ b/assign-pull-requests-codeberg.py
@@ -353,7 +353,7 @@ def assign_one(
                 )
             else:
                 updq = bz.build_update(
-                    keywords_add=["PullRequest"], see_also_add=[pr["url"]]
+                    keywords_add=["PullRequest"], see_also_add=[pr["html_url"]]
                 )
                 try:
                     bz.update_bugs([bug.id for bug in real_bugs], updq)


### PR DESCRIPTION
The pr["url"] field appears to have changed to point to the API instead of the HTML url. Fix by using the "html_url" field instead.

Closes: https://bugs.gentoo.org/979613